### PR TITLE
Add finding first 5 shows in a city skill

### DIFF
--- a/.env.json
+++ b/.env.json
@@ -1,5 +1,6 @@
 {
     "ENV": "development",
     "ARTSY_CLIENT_ID": "8198312f86b95300946b",
-    "ARTSY_CLIENT_SECRET": "99ba69754592e7d4cce2bb319ece15b4"
+    "ARTSY_CLIENT_SECRET": "99ba69754592e7d4cce2bb319ece15b4",
+    "GOOGLE_GEOCODING_API_KEY": "replace-me"
 }

--- a/.env.json
+++ b/.env.json
@@ -1,6 +1,5 @@
 {
     "ENV": "development",
     "ARTSY_CLIENT_ID": "8198312f86b95300946b",
-    "ARTSY_CLIENT_SECRET": "99ba69754592e7d4cce2bb319ece15b4",
-    "GOOGLE_GEOCODING_API_KEY": "replace-me"
+    "ARTSY_CLIENT_SECRET": "99ba69754592e7d4cce2bb319ece15b4"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+  - "4.3"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,6 +58,19 @@ $ make deploy
 
 Go to the Lambda function and choose _Triggers_. Add an `Alexa Skills Kit` trigger or you'll get an obscure `Please make sure that "Alexa Skills Kit" is selected for the event source type of arn:...` error.
 
+### Adding new intents
+
+In case you have added new intents or modified existing ones, follow these steps:
+- Login to https://developer.amazon.com with it@artsymail.com user from 1Password
+- Go to `Alexa` tab
+- Click on `Alexa Skills Kit` get started
+- Select `Artsy`
+- Click `Interaction Model`
+- If you've added a new skill, make sure to add it to `Intent Schema` json section
+- Add/Modify `Custome Slot Types` if needed based on your change.
+- Add/Update `Sample Utterances`.
+- Make sure to save your changes
+
 ### Logs
 
 If logs don't appear in CloudWatch, manually attach the following policy.
@@ -81,6 +94,7 @@ If logs don't appear in CloudWatch, manually attach the following policy.
 
 ### Test
 
+#### In command line
 ```
 apex invoke artsy < test/functions/artsy/fixtures/LaunchRequest.json
 ```
@@ -100,6 +114,10 @@ This should return a welcome message.
   }
 }
 ```
+
+#### Using echosim.io
+
+Go to https://echosim.io/ and login with `it@artsymail.com` and try Artsy's plugin.
 
 ### Production Deployment
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -36,6 +36,12 @@ Install dependent packages and export schema and utterances.
 make build
 ```
 
+### Set Environment Variables
+Make sure `ARTSY_CLIENT_ID` and `ARTSY_CLIENT_SECRET` are set in your environment variables. These are used to access Artsy's API.
+
+#### Google Geocoding API keys
+Elderfield skill uses [Google Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro) to geocode city names to lat/lon. Make sure `GOOGLE_GEOCODING_API_KEY` is set in your environment variables.
+
 ### Deploy to Lambda
 
 ```

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,9 +37,11 @@ make build
 ```
 
 ### Set Environment Variables
+
 Make sure `ARTSY_CLIENT_ID` and `ARTSY_CLIENT_SECRET` are set in your environment variables. These are used to access Artsy's API.
 
 #### Google Geocoding API keys
+
 Elderfield skill uses [Google Geocoding API](https://developers.google.com/maps/documentation/geocoding/intro) to geocode city names to lat/lon. Make sure `GOOGLE_GEOCODING_API_KEY` is set in your environment variables.
 
 ### Deploy to Lambda

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Play [this video](https://youtu.be/zi3OubNiV9U).
 * Alexa, ask Artsy about Pablo Picasso.
 * Alexa, ask Artsy for shows in Brooklyn.
 * Alexa, ask Artsy for shows around Manhattan.
-* Alexa, ask Artsy shows in Brooklyn.
+* Alexa, ask Artsy for current shows in Brooklyn.
 
 ### Deploying to AWS Lambda
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Play [this video](https://youtu.be/zi3OubNiV9U).
 * Alexa, ask Artsy about Andy Warhol
 * Alexa, ask Artsy about Norman Rockwell
 * Alexa, ask Artsy about Pablo Picasso.
+* Alexa, ask Artsy for shows in Brooklyn.
+* Alexa, ask Artsy for shows around Manhattan.
+* Alexa, ask Artsy shows in Brooklyn.
 
 ### Deploying to AWS Lambda
 

--- a/functions/artsy/index.js
+++ b/functions/artsy/index.js
@@ -4,14 +4,14 @@ var xapp = require('./models/xapp');
 var api = require('./models/api');
 var _ = require('underscore');
 var removeMd = require('remove-markdown');
-var NodeGeocoder = require('node-geocoder');
+var nodeGeocoder = require('node-geocoder');
 
 var geocodingOptions = {
   provider: 'google',
   httpAdapter: 'https', // Default
   apiKey: process.env["GOOGLE_GEOCODING_API_KEY"]
 };
-var geocoder = NodeGeocoder(geocodingOptions);
+var geocoder = nodeGeocoder(geocodingOptions);
 
 console.log('Loaded artsy.');
 
@@ -145,9 +145,11 @@ app.intent('ShowsIntent', {
                 geocodeResult = _.first(geoRes);
                 if (_.isEmpty(geoRes)) {
                     res.say(`Sorry, I couldn't find ${city}. Try again?`);
+                    console.log(`app.ShowsIntent: could not geocode city: ${city}.`);
                     res.shouldEndSession(false);
                     res.send();
                 } else {
+                    console.log(`app.ShowsIntent: fetching shows for: ${city}.`);
                     api.instance().then(function(api) {
                         api.findShows(geocodeResult.latitude, geocodeResult.longitude).then(function(results) {
                             var intro = `Current exhibitions around ${city}`

--- a/functions/artsy/index.js
+++ b/functions/artsy/index.js
@@ -130,7 +130,7 @@ app.intent('AboutIntent', {
 
 app.intent('ShowsIntent', {
         "slots": {
-            "CITY": "LITERAL"
+            "CITY": "AMAZON.US_CITY"
         },
         "utterances": [
             "{for|} shows {in|around} {-|CITY}"

--- a/functions/artsy/index.js
+++ b/functions/artsy/index.js
@@ -133,7 +133,7 @@ app.intent('ShowsIntent', {
             "CITY": "AMAZON.US_CITY"
         },
         "utterances": [
-            "{for|} shows {in|around} {-|CITY}"
+            "for {|current} shows {in|around} {-|CITY}"
         ]
     },
     function(req, res) {

--- a/functions/artsy/models/api.js
+++ b/functions/artsy/models/api.js
@@ -48,4 +48,20 @@ Api.prototype.matchArtist = function(name) {
     return deferred.promise;
 }
 
+Api.prototype.findShows = function(lat, lon) {
+    var api = this;
+    var deferred = Q.defer();
+    // TODO: use APIv2 /shows when it supports near param
+    api.get('https://api.artsy.net/api/v1/shows', { near: [lat,lon].join(','), sort: '-featured,-end_at', size: 5 }).then(function(results) {
+        if (results) {
+            deferred.resolve(results);
+        } else {
+            deferred.reject("No shows in this city.")
+        }
+    }).fail(function(error) {
+        deferred.reject(error);
+    });
+    return deferred.promise;
+}
+
 module.exports = Api;

--- a/functions/artsy/package.json
+++ b/functions/artsy/package.json
@@ -13,6 +13,7 @@
         "alexa-app": "^2.3.4",
         "superagent": "2.3.0",
         "underscore": "1.8.3",
-        "remove-markdown": "0.1.0"
+        "remove-markdown": "0.1.0",
+        "node-geocoder": "^3.15.2"
     }
 }

--- a/functions/artsy/schema.json
+++ b/functions/artsy/schema.json
@@ -26,7 +26,7 @@
          "slots": [
             {
                "name": "CITY",
-               "type": "LITERAL"
+               "type": "AMAZON.US_CITY"
             }
          ]
       }

--- a/functions/artsy/schema.json
+++ b/functions/artsy/schema.json
@@ -20,6 +20,15 @@
                "type": "NAME"
             }
          ]
+      },
+      {
+         "intent": "ShowsIntent",
+         "slots": [
+            {
+               "name": "CITY",
+               "type": "LITERAL"
+            }
+         ]
       }
    ]
 }

--- a/functions/artsy/utterances.txt
+++ b/functions/artsy/utterances.txt
@@ -2,3 +2,7 @@ AMAZON.StopIntent	stop
 AMAZON.CancelIntent	cancel
 AMAZON.HelpIntent	help
 AboutIntent	about {VALUE}
+ShowsIntent	for shows in {CITY}
+ShowsIntent	shows in {CITY}
+ShowsIntent	for shows around {CITY}
+ShowsIntent	shows around {CITY}

--- a/functions/artsy/utterances.txt
+++ b/functions/artsy/utterances.txt
@@ -3,6 +3,6 @@ AMAZON.CancelIntent	cancel
 AMAZON.HelpIntent	help
 AboutIntent	about {VALUE}
 ShowsIntent	for shows in {CITY}
-ShowsIntent	shows in {CITY}
+ShowsIntent	for current shows in {CITY}
 ShowsIntent	for shows around {CITY}
-ShowsIntent	shows around {CITY}
+ShowsIntent	for current shows around {CITY}

--- a/package.json
+++ b/package.json
@@ -1,22 +1,23 @@
 {
-    "name": "elderfield",
-    "version": "0.0.1",
-    "private": true,
-    "engines": {
-        "node": "4.3.x",
-        "npm": "4.x.x"
-    },
-    "scripts": {
-        "start": "make s",
-        "test": "make test"
-    },
-    "dependencies": {
-        "alexa-app-server": "2.2.4"
-    },
-    "devDependencies": {
-        "mocha": "3.1.2",
-        "chai": "3.5.0",
-        "chai-http": "3.0.0",
-        "chai-string": "1.3.0"
-    }
+  "name": "elderfield",
+  "version": "0.0.1",
+  "private": true,
+  "engines": {
+    "node": "4.3.x",
+    "npm": "4.x.x"
+  },
+  "scripts": {
+    "start": "make s",
+    "test": "make test"
+  },
+  "dependencies": {
+    "alexa-app-server": "2.2.4",
+    "node-geocoder": "^3.15.2"
+  },
+  "devDependencies": {
+    "mocha": "3.1.2",
+    "chai": "3.5.0",
+    "chai-http": "3.0.0",
+    "chai-string": "1.3.0"
+  }
 }

--- a/test/functions/artsy/fixtures/ShowsIntentRequest.json
+++ b/test/functions/artsy/fixtures/ShowsIntentRequest.json
@@ -1,0 +1,29 @@
+{
+    "session": {
+        "sessionId": "SessionId.ca05ce5f-3b70-49be-84b5-bdc3086533fb",
+        "application": {
+            "applicationId": "amzn1.ask.skill.42004f60-1c66-4c61-8c5d-9006303e6ec4"
+        },
+        "attributes": {},
+        "user": {
+            "userId": "amzn1.ask.account.xyz"
+        },
+        "new": true
+    },
+    "request": {
+        "type": "IntentRequest",
+        "requestId": "EdwRequestId.624219fd-68b1-41ba-b02b-a1bf54dfe180",
+        "locale": "en-US",
+        "timestamp": "2016-11-12T22:03:54Z",
+        "intent": {
+            "name": "ShowsIntent",
+            "slots": {
+                "CITY": {
+                    "name": "CITY",
+                    "value": "Brooklyn"
+                }
+            }
+        }
+    },
+    "version": "1.0"
+}

--- a/test/functions/artsy/test-launch.js
+++ b/test/functions/artsy/test-launch.js
@@ -12,7 +12,7 @@ describe('artsy alexa', function() {
                 // the session must remain open for a user response
                 expect(data.response.shouldEndSession).to.equal(false);
                 // a welcome prompt must be provided which describes what users can ask of the skill
-                expect(data.response.outputSpeech.ssml).to.equal('<speak>Welcome to Artsy! Ask me about an artist.</speak>');
+                expect(data.response.outputSpeech.ssml).to.equal('<speak>Welcome to Artsy! Ask me about an artist, or shows in your city.</speak>');
                 expect(data.response.reprompt.outputSpeech.ssml).to.equal('<speak>Say help if you need help or exit any time to exit. What artist would you like to hear about?</speak>');
                 done();
             });

--- a/test/functions/artsy/test-shows.js
+++ b/test/functions/artsy/test-shows.js
@@ -1,0 +1,42 @@
+require('../../setup');
+
+describe('artsy alexa', function() {
+    showsIntentRequest = function(cityName, cb) {
+        var showsIntentRequest = require('./fixtures/ShowsIntentRequest.json');
+        showsIntentRequest.request.intent.slots.CITY.value = cityName;
+        chai.request(server)
+            .post('/alexa/artsy')
+            .send(showsIntentRequest)
+            .end(function(err, res) {
+                expect(res.status).to.equal(200);
+                var data = JSON.parse(res.text);
+                expect(data.response.outputSpeech.type).to.equal('SSML')
+                cb(data.response);
+            });
+    }
+
+    it('speaks about shows in brooklyn', function(done) {
+        showsIntentRequest('brooklyn', function(response) {
+            expect(response.outputSpeech.ssml).to.startWith('<speak>Current exhibitions around brooklyn: ');
+            expect(response.outputSpeech.ssml).to.endWith('</speak>');
+            expect(response.shouldEndSession).to.equal(true);
+            done();
+        });
+    });
+
+    it('properly handles unknown cities', function(done) {
+        showsIntentRequest('gibberish', function(response) {
+            expect(response.outputSpeech.ssml).to.equal("<speak>Sorry, I couldn't find gibberish. Try again?</speak>");
+            expect(response.shouldEndSession).to.equal(false);
+            done();
+        });
+    });
+
+    it('properly handles cities without shows', function(done) {
+        showsIntentRequest('kerman', function(response) {
+            expect(response.outputSpeech.ssml).to.equal("<speak>Sorry, I couldn't find any shows in kerman. Try again?</speak>");
+            expect(response.shouldEndSession).to.equal(false);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
# Feature
Add finding first 5 current shows by city. With this PR, Artsy's skill will be able to understand following commands:
```
Alexa, ask Artsy for shows in <city>.
Alexa, ask Artsy for shows around <city>.
Alexa, ask Artsy shows in <city>.
Alexa, ask Artsy shows around <city>.
```

Fixes #6 

# Changes
New `ShowsIntent` is added in `index.js` which is triggered by following utterances:
```
ShowsIntent	for shows in {CITY}
ShowsIntent	shows in {CITY}
ShowsIntent	for shows around {CITY}
ShowsIntent	shows around {CITY}
```
Once received these commands, it will:
- Geocode city name and find it's `lat`, `lon`
- Calls Artsy's `api/v1/shows` endpoint and passing `lat`, `lon` to get first five shows near this point and returns the results.

## Geocoding
Added dependency to [node-geocoder](https://github.com/nchaulet/node-geocoder) which is used to geocode city names to `lat`, `lon`. We are using `google` as geocoding provider, we need to make sure `GOOGLE_GEOCODING_API_KEY` is set in environment variables

## Other changes
Not sure if you like this format or not, but switched to JS [string interpolation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) in `index.js`. 
```js
res.say("Sorry, I couldn't find an artist " + value + ". Try again?"); // OLD
res.say(`Sorry, I couldn't find an artist ${value}. Try again?`); // NEW
```