### PR TITLE
Removed node-geocoder from the server's package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
         "danger": "./node_modules/.bin/danger"
     },
     "dependencies": {
-        "alexa-app-server": "2.2.4",
-        "node-geocoder": "^3.15.2"
+        "alexa-app-server": "2.2.4"
     },
     "devDependencies": {
         "mocha": "3.1.2",


### PR DESCRIPTION
If I am not mistaken we only need the geocoder for the skill itself, but not for the dev server.