### PR TITLE
Clarified instructions for production deployment.

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -121,17 +121,9 @@ Go to https://echosim.io/ and login with `it@artsymail.com` and try Artsy's plug
 
 ### Production Deployment
 
-You need Artsy Alexa `project.production.json` and access to the Artsy AWS infrastructure. If you work at Artsy, you will find it in 1Password in the Engineering vault under `elderfield (Alexa) project.production.json`.
+You need Artsy Alexa `project.production.json` and access to the Artsy AWS infrastructure. If you work at Artsy, you will find it in 1Password in the Engineering vault under `project.production.json - Alexa (elderfield) production envs`. Place the file at the root of your git clone.
 
-Make sure following environment variables are set in AWS Lambda settings:
-```
-ARTSY_BASE_API_URL=replace-me
-ARTSY_CLIENT_ID=replace-me
-ARTSY_CLIENT_SECRET=replace-me
-ENV=lambda
-```
-
-Then run: 
+Run:
 
 ```
 make production-deploy


### PR DESCRIPTION
The instructions are correct. The `apex deploy` overrides environment settings, so for production we use a `project.production.json` file with all the settings, including `GOOGLE_GEOCODING_API_KEY` or `ARTSY_CLIENT_SECRET`.

I've updated that file in 1Password attached to "Alexa (elderfield) production envs", it's called "project.production.json - Alexa (elderfield) production envs". 

To deploy to production, place that file at the root of Elderfiled and do `make production-deploy`. 

In the future to add a new variable (like the `GOOGLE_GEOCODING_API_KEY`) we need to add it to this file and everyone will have to get the updated version.

That said, https://github.com/apex/apex/issues/613 would make things a lot easier.

Closes #37.

